### PR TITLE
added obj && prior to 'does obj.original$ exist' check - prevents crashes if obj is not defined

### DIFF
--- a/lib/AccessControlList.js
+++ b/lib/AccessControlList.js
@@ -267,7 +267,7 @@ AccessControlList.prototype._conditionMatch = function(condition, obj, action, c
         }
 
         var actualValue
-        if (obj.original$) {
+        if (obj && obj.original$) {
           actualValue = this._objectParser.lookup(attr, obj.original$)
         }
         else {


### PR DESCRIPTION
...I'm aware this crash may be the point - this needs review for sure.
